### PR TITLE
Allow impl for generic structs on `#[derive(PgSchema)]`

### DIFF
--- a/btreemapped_derive/src/derive_pg_schema.rs
+++ b/btreemapped_derive/src/derive_pg_schema.rs
@@ -58,9 +58,11 @@ pub fn derive_pg_schema(input: TokenStream) -> TokenStream {
 
     let num_fields = all_fields_idents.len();
 
+    let (impl_generics, ty_generics, where_generics) = input.generics.split_for_impl();
+
     // Generate the impl block for BTreeMapped
     let impl_block = quote! {
-        impl PgSchema for #struct_name {
+        impl #impl_generics PgSchema for #struct_name #ty_generics #where_generics {
             fn column_names() -> impl ExactSizeIterator<Item = &'static str> {
                 [
                     #(#all_fields_names),*


### PR DESCRIPTION
Generates proper generics in impl when needed (would error before)
```rust
// This works now
#[derive(PgSchema)]
struct Example<'a> {
  #[pg_type(Type::NUMERIC)]
  x: &'a u32
}
```