### PR TITLE
feat!: upgrade etl dependency to supabase/etl 7f3f240

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 derive_more = { version = "1", features = ["try_into"] }
 env_logger = "0.11"
-etl = { git = "https://github.com/architect-xyz/etl.git", rev = "978af896f9d99c5ba525614e17aca9046f1d506f", default-features = false }
-etl-postgres = { git = "https://github.com/architect-xyz/etl.git", rev = "978af896f9d99c5ba525614e17aca9046f1d506f", default-features = false, features = [
+etl = { git = "https://github.com/supabase/etl.git", rev = "7f3f240442c18d228c97f861fa4352232dc6eec4", default-features = false }
+etl-postgres = { git = "https://github.com/supabase/etl.git", rev = "7f3f240442c18d228c97f861fa4352232dc6eec4", default-features = false, features = [
   "replication",
 ] }
 futures = "0.3"

--- a/btreemapped/examples/basic.rs
+++ b/btreemapped/examples/basic.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgSchema};
-use btreemapped_derive::{BTreeMapped, PgSchema};
-use etl::config::{BatchConfig, PgConnectionConfig, PipelineConfig, TlsConfig};
+use etl::config::{
+    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+};
 use postgres_types::Type;
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
@@ -87,7 +88,7 @@ fn pg_config() -> PgConnectionConfig {
             trusted_root_certs: "".to_string(),
             enabled: false,
         },
-        keepalive: None,
+        keepalive: TcpKeepaliveConfig::default(),
     }
 }
 
@@ -105,6 +106,8 @@ fn pipeline_config() -> PipelineConfig {
         table_error_retry_delay_ms: 10000,
         table_error_retry_max_attempts: 5,
         max_table_sync_workers: 4,
-        slot_prefix: "examples_basic".to_string(),
+        max_copy_connections_per_table: 1,
+        table_sync_copy: Default::default(),
+        invalidated_slot_behavior: Default::default(),
     }
 }

--- a/btreemapped/examples/basic.rs
+++ b/btreemapped/examples/basic.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgSchema};
-use etl::config::{
+use btreemapped::config::{
     BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
 };
 use postgres_types::Type;

--- a/btreemapped/examples/basic.rs
+++ b/btreemapped/examples/basic.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
-use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgSchema};
-use btreemapped::config::{
-    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+use btreemapped::{
+    config::{
+        BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+    },
+    replicator::BTreeMapReplicator,
+    BTreeMapped, LIndex1, PgSchema,
 };
 use postgres_types::Type;
 use serde::Serialize;

--- a/btreemapped/src/lib.rs
+++ b/btreemapped/src/lib.rs
@@ -11,6 +11,19 @@ pub mod replica;
 pub mod replicator;
 pub(crate) mod sink;
 
+/// Re-exported configuration types from [`etl`].
+///
+/// Use `pipeline_id` (the `id` field on [`PipelineConfig`]) to distinguish
+/// between multiple replication pipelines.  It determines the replication
+/// slot names on the Postgres side (`supabase_etl_apply_{pipeline_id}`,
+/// `supabase_etl_table_sync_{pipeline_id}_{table_id}`).
+pub mod config {
+    pub use etl::config::{
+        BatchConfig, InvalidatedSlotBehavior, PgConnectionConfig, PipelineConfig,
+        TableSyncCopyConfig, TcpKeepaliveConfig, TlsConfig,
+    };
+}
+
 #[cfg(feature = "derive")]
 pub use btreemapped_derive::{BTreeMapped, PgSchema};
 pub use json::PgJson;

--- a/btreemapped/src/replicator.rs
+++ b/btreemapped/src/replicator.rs
@@ -31,7 +31,7 @@ struct Inner {
     fully_synced: bool,
     /// Current replication state for each table - this is the authoritative source of truth
     /// for table states. Every table being replicated must have an entry here.
-    table_replication_states: HashMap<TableId, TableReplicationPhase>,
+    table_replication_states: BTreeMap<TableId, TableReplicationPhase>,
     /// Complete history of state transitions for each table, used for debugging and auditing.
     /// This is an append-only log that grows over time and provides visibility into
     /// table state evolution. Entries are chronologically ordered.
@@ -72,7 +72,7 @@ impl BTreeMapReplicator {
             committed_lsn: 0,
             txn_lsn: None,
             fully_synced: false,
-            table_replication_states: HashMap::new(),
+            table_replication_states: BTreeMap::new(),
             table_state_history: HashMap::new(),
             table_schemas: HashMap::new(),
             table_mappings: HashMap::new(),
@@ -157,7 +157,7 @@ impl StateStore for BTreeMapReplicator {
     ) -> EtlResult<BTreeMap<TableId, TableReplicationPhase>> {
         let inner = self.inner.lock();
 
-        Ok(inner.table_replication_states.iter().map(|(&k, v)| (k, v.clone())).collect())
+        Ok(inner.table_replication_states.clone())
     }
 
     async fn load_table_replication_states(&self) -> EtlResult<usize> {

--- a/btreemapped/tests/test_cdc_events.rs
+++ b/btreemapped/tests/test_cdc_events.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use etl::config::{
+use btreemapped::config::{
     BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
 };
 use tokio_util::sync::CancellationToken;

--- a/btreemapped/tests/test_cdc_events.rs
+++ b/btreemapped/tests/test_cdc_events.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
-use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use btreemapped::config::{
-    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+use btreemapped::{
+    config::{
+        BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+    },
+    replicator::BTreeMapReplicator,
+    BTreeMapped, LIndex1,
 };
 use tokio_util::sync::CancellationToken;
 use utils::{create_postgres_client, setup_postgres_container};

--- a/btreemapped/tests/test_cdc_events.rs
+++ b/btreemapped/tests/test_cdc_events.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use etl::config::{BatchConfig, PgConnectionConfig, PipelineConfig, TlsConfig};
+use etl::config::{
+    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+};
 use tokio_util::sync::CancellationToken;
 use utils::{create_postgres_client, setup_postgres_container};
 
@@ -47,7 +49,7 @@ fn pipeline_config(host: &str, port: u16) -> PipelineConfig {
                 trusted_root_certs: "".to_string(),
                 enabled: false,
             },
-            keepalive: None,
+            keepalive: TcpKeepaliveConfig::default(),
         },
         batch: BatchConfig {
             max_size: 100,
@@ -56,7 +58,9 @@ fn pipeline_config(host: &str, port: u16) -> PipelineConfig {
         table_error_retry_delay_ms: 1000,
         table_error_retry_max_attempts: 3,
         max_table_sync_workers: 4,
-        slot_prefix: "test_cdc_events".to_string(),
+        max_copy_connections_per_table: 1,
+        table_sync_copy: Default::default(),
+        invalidated_slot_behavior: Default::default(),
     }
 }
 

--- a/btreemapped/tests/test_error_recovery.rs
+++ b/btreemapped/tests/test_error_recovery.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use etl::config::{
+use btreemapped::config::{
     BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
 };
 use tokio_util::sync::CancellationToken;

--- a/btreemapped/tests/test_error_recovery.rs
+++ b/btreemapped/tests/test_error_recovery.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use etl::config::{BatchConfig, PgConnectionConfig, PipelineConfig, TlsConfig};
+use etl::config::{
+    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+};
 use tokio_util::sync::CancellationToken;
 use utils::{create_postgres_client, setup_postgres_container};
 
@@ -27,7 +29,7 @@ fn pipeline_config(host: &str, port: u16) -> PipelineConfig {
                 trusted_root_certs: "".to_string(),
                 enabled: false,
             },
-            keepalive: None,
+            keepalive: TcpKeepaliveConfig::default(),
         },
         batch: BatchConfig {
             max_size: 100,
@@ -36,7 +38,9 @@ fn pipeline_config(host: &str, port: u16) -> PipelineConfig {
         table_error_retry_delay_ms: 500,
         table_error_retry_max_attempts: 5,
         max_table_sync_workers: 4,
-        slot_prefix: "test_recovery".to_string(),
+        max_copy_connections_per_table: 1,
+        table_sync_copy: Default::default(),
+        invalidated_slot_behavior: Default::default(),
     }
 }
 

--- a/btreemapped/tests/test_error_recovery.rs
+++ b/btreemapped/tests/test_error_recovery.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
-use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use btreemapped::config::{
-    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+use btreemapped::{
+    config::{
+        BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+    },
+    replicator::BTreeMapReplicator,
+    BTreeMapped, LIndex1,
 };
 use tokio_util::sync::CancellationToken;
 use utils::{create_postgres_client, setup_postgres_container};

--- a/btreemapped/tests/test_json_replication.rs
+++ b/btreemapped/tests/test_json_replication.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use btreemapped::{
     replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgJson, PgSchema,
 };
-use etl::config::{
+use btreemapped::config::{
     BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
 };
 use postgres_types::Type;

--- a/btreemapped/tests/test_json_replication.rs
+++ b/btreemapped/tests/test_json_replication.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use btreemapped::{
-    replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgJson, PgSchema,
-};
-use btreemapped::config::{
-    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+    config::{
+        BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+    },
+    replicator::BTreeMapReplicator,
+    BTreeMapped, LIndex1, PgJson, PgSchema,
 };
 use postgres_types::Type;
 use serde::Serialize;

--- a/btreemapped/tests/test_json_replication.rs
+++ b/btreemapped/tests/test_json_replication.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use btreemapped::{
     replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgJson, PgSchema,
 };
-use etl::config::{BatchConfig, PgConnectionConfig, PipelineConfig, TlsConfig};
+use etl::config::{
+    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+};
 use postgres_types::Type;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -86,7 +88,7 @@ fn pg_config(host: &str, port: u16) -> PgConnectionConfig {
             trusted_root_certs: "".to_string(),
             enabled: false,
         },
-        keepalive: None,
+        keepalive: TcpKeepaliveConfig::default(),
     }
 }
 
@@ -102,7 +104,9 @@ fn pipeline_config(host: &str, port: u16) -> PipelineConfig {
         table_error_retry_delay_ms: 1000,
         table_error_retry_max_attempts: 3,
         max_table_sync_workers: 4,
-        slot_prefix: "test_json_replication".to_string(),
+        max_copy_connections_per_table: 1,
+        table_sync_copy: Default::default(),
+        invalidated_slot_behavior: Default::default(),
     }
 }
 

--- a/btreemapped/tests/test_parse_errors.rs
+++ b/btreemapped/tests/test_parse_errors.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
-use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use btreemapped::config::{
-    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+use btreemapped::{
+    config::{
+        BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+    },
+    replicator::BTreeMapReplicator,
+    BTreeMapped, LIndex1,
 };
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;

--- a/btreemapped/tests/test_parse_errors.rs
+++ b/btreemapped/tests/test_parse_errors.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use etl::config::{
+use btreemapped::config::{
     BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
 };
 use serde::{Deserialize, Serialize};

--- a/btreemapped/tests/test_parse_errors.rs
+++ b/btreemapped/tests/test_parse_errors.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1};
-use etl::config::{BatchConfig, PgConnectionConfig, PipelineConfig, TlsConfig};
+use etl::config::{
+    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use utils::{create_postgres_client, setup_postgres_container};
@@ -70,7 +72,7 @@ fn strict_pipeline_config(host: &str, port: u16) -> PipelineConfig {
                 trusted_root_certs: "".to_string(),
                 enabled: false,
             },
-            keepalive: None,
+            keepalive: TcpKeepaliveConfig::default(),
         },
         batch: BatchConfig {
             max_size: 100,
@@ -79,7 +81,9 @@ fn strict_pipeline_config(host: &str, port: u16) -> PipelineConfig {
         table_error_retry_delay_ms: 1000,
         table_error_retry_max_attempts: 3,
         max_table_sync_workers: 4,
-        slot_prefix: "test_strict".to_string(),
+        max_copy_connections_per_table: 1,
+        table_sync_copy: Default::default(),
+        invalidated_slot_behavior: Default::default(),
     }
 }
 
@@ -220,7 +224,7 @@ fn status_pipeline_config(host: &str, port: u16) -> PipelineConfig {
                 trusted_root_certs: "".to_string(),
                 enabled: false,
             },
-            keepalive: None,
+            keepalive: TcpKeepaliveConfig::default(),
         },
         batch: BatchConfig {
             max_size: 100,
@@ -229,7 +233,9 @@ fn status_pipeline_config(host: &str, port: u16) -> PipelineConfig {
         table_error_retry_delay_ms: 1000,
         table_error_retry_max_attempts: 3,
         max_table_sync_workers: 4,
-        slot_prefix: "test_status".to_string(),
+        max_copy_connections_per_table: 1,
+        table_sync_copy: Default::default(),
+        invalidated_slot_behavior: Default::default(),
     }
 }
 

--- a/btreemapped/tests/test_replication.rs
+++ b/btreemapped/tests/test_replication.rs
@@ -1,9 +1,12 @@
 #![cfg(feature = "rust_decimal")]
 
 use anyhow::Result;
-use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgSchema};
-use btreemapped::config::{
-    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+use btreemapped::{
+    config::{
+        BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+    },
+    replicator::BTreeMapReplicator,
+    BTreeMapped, LIndex1, PgSchema,
 };
 use postgres_types::Type;
 use rust_decimal::Decimal;

--- a/btreemapped/tests/test_replication.rs
+++ b/btreemapped/tests/test_replication.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgSchema};
-use etl::config::{
+use btreemapped::config::{
     BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
 };
 use postgres_types::Type;

--- a/btreemapped/tests/test_replication.rs
+++ b/btreemapped/tests/test_replication.rs
@@ -2,7 +2,9 @@
 
 use anyhow::Result;
 use btreemapped::{replicator::BTreeMapReplicator, BTreeMapped, LIndex1, PgSchema};
-use etl::config::{BatchConfig, PgConnectionConfig, PipelineConfig, TlsConfig};
+use etl::config::{
+    BatchConfig, PgConnectionConfig, PipelineConfig, TcpKeepaliveConfig, TlsConfig,
+};
 use postgres_types::Type;
 use rust_decimal::Decimal;
 use tokio_util::sync::CancellationToken;
@@ -75,7 +77,7 @@ fn pg_config(host: &str, port: u16) -> PgConnectionConfig {
             trusted_root_certs: "".to_string(),
             enabled: false,
         },
-        keepalive: None,
+        keepalive: TcpKeepaliveConfig::default(),
     }
 }
 
@@ -91,7 +93,9 @@ fn pipeline_config(host: &str, port: u16) -> PipelineConfig {
         table_error_retry_delay_ms: 1000,
         table_error_retry_max_attempts: 3,
         max_table_sync_workers: 4,
-        slot_prefix: "test_replication".to_string(),
+        max_copy_connections_per_table: 1,
+        table_sync_copy: Default::default(),
+        invalidated_slot_behavior: Default::default(),
     }
 }
 

--- a/btreemapped/tests/utils/mod.rs
+++ b/btreemapped/tests/utils/mod.rs
@@ -18,7 +18,13 @@ pub async fn setup_postgres_container(
         .with_env_var("POSTGRES_PASSWORD", "postgres")
         .with_env_var("POSTGRES_USER", "postgres")
         .with_env_var("POSTGRES_DB", "testdb")
-        .with_cmd(vec!["postgres", "-c", "wal_level=logical"])
+        .with_cmd(vec![
+            "postgres",
+            "-c",
+            "wal_level=logical",
+            "-c",
+            "wal_sender_timeout=5s",
+        ])
         .start()
         .await?;
 

--- a/justfile
+++ b/justfile
@@ -1,9 +1,5 @@
 nightly := "nightly-2025-12-07"
 
-# List available recipes
-default:
-    @just --list
-
 # Run tests with coverage (lcov output)
 coverage:
     cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
@@ -11,6 +7,10 @@ coverage:
 # Run tests with coverage and open HTML report
 coverage-html:
     cargo llvm-cov --all-features --workspace --html --open
+
+# List available recipes
+default:
+    @just --list
 
 # Restart postgres and run the basic example
 example:
@@ -30,3 +30,7 @@ format:
 # Run clippy lints
 lint:
     cargo clippy --all-features --workspace -- -D warnings
+
+# Run tests like CI (all features, all workspace crates)
+test:
+    cargo test --all-features --workspace


### PR DESCRIPTION
## Summary

- Switch etl dependency from `architect-xyz/etl` fork to upstream `supabase/etl` at commit `7f3f240442c18d228c97f861fa4352232dc6eec4`
- Adapt to all upstream breaking changes in `StateStore`, `PipelineConfig`, and `PgConnectionConfig`
- Fix test container configuration for new `SyncWait` → `Catchup` state handoff that requires timely keepalives

## Breaking changes from upstream

| Area | Change |
|------|--------|
| `StateStore::get_table_replication_states` | Returns `BTreeMap` instead of `HashMap` |
| `StateStore::update_table_replication_state` | Replaced by batch `update_table_replication_states(Vec<(TableId, TableReplicationPhase)>)` |
| `PipelineConfig` | `slot_prefix` removed; `max_copy_connections_per_table`, `table_sync_copy`, `invalidated_slot_behavior` added |
| `PgConnectionConfig::keepalive` | Changed from `Option<_>` to `TcpKeepaliveConfig` (non-optional, has `Default`) |

## Notable fix

The new etl version introduces a `SyncWait` intermediate state between `FinishedCopy` and `Catchup`. The table sync worker enters `SyncWait` and waits for the apply worker to transition it, but the apply worker only checks on replication messages (including keepalives). PostgreSQL's default `wal_sender_timeout=60s` means keepalives arrive every ~30s, which exceeded the 10s test timeout. Fixed by setting `wal_sender_timeout=5s` on test containers.

## Additional

- Fix duplicate derive macro imports in `examples/basic.rs`
- Add `just test` recipe and alphabetize justfile

## Test plan

- [x] All 80 unit tests pass
- [x] All 8 integration tests pass (`just test`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)